### PR TITLE
Refactor [ShowContext] using reactive statement

### DIFF
--- a/src/testUtil/context/ShowContext.svelte
+++ b/src/testUtil/context/ShowContext.svelte
@@ -5,10 +5,13 @@
 
     let theme;
     let themeType;
+    let themeText;
 
-    Theme.subscribe((value) => { theme = value.theme; themeType = value.themeType; });
-
-    $: themeText = JSON.stringify(theme);
+    $: {
+      theme = $Theme.theme;
+      themeType = $Theme.themeType;
+      themeText = JSON.stringify(theme);
+    }
 </script>
 
 <p>{themeType}</p>


### PR DESCRIPTION
Refactor `ShowContext`(testUtil) using [reactive statement](https://svelte.dev/docs#3_$_marks_a_statement_as_reactive).