### PR TITLE
Add rgb variables using hex code

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ The `theme` props will be converted to `kebab-case` in global css variables. For
 </style>
 ```
 
+If you want to add opacity to theme color, you should use `color-rgb` instead of `color`.
+
+```js
+<style>
+  p {
+    color: rgba(var(--main-dark), 0.2);
+  }
+</style>
+```
+
+Note that `rgb value` is calculated based on color code, which is assumed to be `7 degit hex code`.
+
 ## Customizing theme
 
 #### 1. Define colors for `light` and `dark` theme.

--- a/src/ThemeProvider.svelte
+++ b/src/ThemeProvider.svelte
@@ -31,7 +31,7 @@
   });
 
   const setCssVars = (current: Partial<Theme> & JSONObject) => {
-    Object.entries(current).forEach(([type, color]) => {
+    Object.entries(current).forEach(([type, hex]) => {
       const kebabize = (str: string) =>
         str
           .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
@@ -40,7 +40,18 @@
 
       const varString = `--${kebabize(type)}`;
 
-      document.documentElement.style.setProperty(varString, color);
+      const hexToRgb = (hex: string) => {
+        const parsed = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+        const [r, g, b] = parsed.slice(1).map((s: string) => parseInt(s, 16));
+
+        return `${r},${g},${b}`;
+      };
+
+      const rgb = hexToRgb(hex);
+
+      document.documentElement.style.setProperty(varString, hex);
+      document.documentElement.style.setProperty(varString + '-rgb', rgb);
     });
   };
 

--- a/src/__tests__/__snapshots__/theme.test.ts.snap
+++ b/src/__tests__/__snapshots__/theme.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render without error 1`] = `
+exports[`svelte-theme renders without error 1`] = `
 <body>
   <div>
     <div />

--- a/src/__tests__/theme.test.ts
+++ b/src/__tests__/theme.test.ts
@@ -1,9 +1,27 @@
-// @ts-ignore
-import SampleComponent from "../../test/SampleComponent.svelte";
 import {render} from "@testing-library/svelte";
 
-it("should render without error", () => {
-  const testngLib = render(SampleComponent);
+import SampleComponent from "../../test/SampleComponent.svelte";
 
-  expect(testngLib.container).toMatchSnapshot();
+describe('svelte-theme', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // Deprecated
+        removeListener: jest.fn(), // Deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+  
+  it("renders without error", () => {
+    const testngLib = render(SampleComponent);
+  
+    expect(testngLib.container).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Before: `rgba(--var(--main), 0.3)` is not working.

After: `rgba(--var(--main-rgb), 0.3)` can be used for alternative.