### PR TITLE
Support sveltekit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-theme",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Svelte theme package",
   "main": "lib/index.js",
   "types": "lib/ts/index.d.ts",

--- a/src/ThemeProvider.svelte
+++ b/src/ThemeProvider.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {onMount, setContext} from 'svelte';
   import {writable} from 'svelte/store';
+  import {browser} from '$app/env';
 
   import {
     ThemeType,
@@ -20,7 +21,7 @@
     dark: {...theme.dark, ...customTheme?.dark},
   };
 
-  const darkSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const darkSchemeQuery = browser ? window.matchMedia('(prefers-color-scheme: dark)') : {matches: false};
 
   if (darkSchemeQuery.matches) initialThemeType = 'dark';
 
@@ -53,8 +54,10 @@
 
       const rgb = hexToRgb(hex);
 
-      document.documentElement.style.setProperty(varString, hex);
-      document.documentElement.style.setProperty(varString + '-rgb', rgb);
+      if (browser) {
+        document.documentElement.style.setProperty(varString, hex);
+        document.documentElement.style.setProperty(varString + '-rgb', rgb);
+      }
     });
   };
 


### PR DESCRIPTION
The default router in sveltekit does not recognize `document` or `window` if the app is in `server-side-rendering`. Detect whether the app is currenlty in browser so that package wont throw the error.